### PR TITLE
fix: remove /blog redirect

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,7 +29,6 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
   redirects: {
-    "/blog/[...slug]": "/articles/[...slug]",
     "/company": "/company/about",
     "/services": "/services/software-development",
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automatic URL redirect from `/blog/[...slug]` to `/articles/[...slug]`. Existing redirects remain in place.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->